### PR TITLE
Remove dataLayer explicit declaration on top of the container snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ the existing ones.
 
 In order for the `push` API so be usable, the *dataLayer* must first be
 declared as an array, the GTM JavaScript snippet inserted at the
-top of the body will declare it for us.
+top of the body will declare it for you.
 
-This initial declaration must occur before snippet. Since the snippet
-must appear at the very top of the body, then the *dataLayer* declaration
-must be the very first item in the body.
+If your *tags* need to fire when pages load, but need information beyond URL
+and referrer, you may need to define the *dataLayer* and pushes information to
+it. Add this code above the container snippet so that the data layer information
+is available on page load. Note that every page must have the code to create a
+*dataLayer* and push information to it; the *dataLayer* does not persist across
+pages.
 
 ## Contributing
 

--- a/lib/rack/google_tag_manager.rb
+++ b/lib/rack/google_tag_manager.rb
@@ -48,7 +48,6 @@ module Rack
 </noscript>
 
 <script>
-  dataLayer = [];
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/spec/lib/rack_google_tag_manager_spec.rb
+++ b/spec/lib/rack_google_tag_manager_spec.rb
@@ -12,10 +12,6 @@ module Rack
       it 'adds the container snippet after body tag' do
         expect(subject).to match(%r[<body.*?>.*#{tracker_id}.*Works!<\/body>]m)
       end
-
-      it 'includes the dataLayer declaration' do
-        expect(subject).to include('dataLayer = []')
-      end
     end
 
     context 'for a text/html response with uppercase html tags' do


### PR DESCRIPTION
In order of being able to pass information to GTM tags fired when pages load, it
needs to stop overwriting the dataLayer object with an empty Array. Furthermore,
explicit declaration of the dataLayer object as an empty string is not required,
GTM already does it.
