### PR TITLE
Fix a circular argument reference warning for ruby-2.2

### DIFF
--- a/lib/rack/google_tag_manager.rb
+++ b/lib/rack/google_tag_manager.rb
@@ -2,7 +2,7 @@ require 'rack'
 
 module Rack
   class GoogleTagManager
-    def initialize(app, tracker: tracker)
+    def initialize(app, tracker: nil)
       @app, @tracker = app, tracker
     end
 


### PR DESCRIPTION
The named param for tracker was referencing itself, this was setting the
default to nil.
