### PR TITLE
Turned off RocketScript if Served by Cloudflare

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 rvm:
-  - 2.0.0
   - 2.1
+  - 2.2
+before_install:
+  - gem install bundler

--- a/lib/rack/google_tag_manager.rb
+++ b/lib/rack/google_tag_manager.rb
@@ -47,7 +47,7 @@ module Rack
   </iframe>
 </noscript>
 
-<script>
+<script data-cfasync="false">
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/lib/rack/google_tag_manager/version.rb
+++ b/lib/rack/google_tag_manager/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class GoogleTagManager
-    VERSION = '1.0.2'
+    VERSION = '1.0.3'
   end
 end


### PR DESCRIPTION
An issues has arisen where if Google Tag Managers third party scripts are loaded via Cloudflare they were converted into RocketScript and the load is deferred until window.load time.  As well as this it can cause some of the third party scripts to be rendered on the CloudFlare server instead of client side which can cause some issues around handshaking over SSL.

You can read more about RocketScript/Rocket Loader on the CloudFlare site at: [CloudFlare Support Article: What does Rocket Loader do?](https://support.cloudflare.com/hc/en-us/articles/200168056-What-does-Rocket-Loader-do-)
